### PR TITLE
Add ui_mode to Panels

### DIFF
--- a/Tools/OSD/OSD.cs
+++ b/Tools/OSD/OSD.cs
@@ -281,19 +281,19 @@ namespace OSD {
                 var pi = scr[n].panelItems;
 
                 // Display name,printfunction,X,Y,ENaddress,Xaddress,Yaddress
-                pi[a++] = new Panel("Horizon", pan.panHorizon, 8, 5, panHorizon_XY, 1, 0, "Show HUD frame", 0, "Show ILS", 1, "Show Radar", 0 , "  with track"); // first!
+                pi[a++] = new Panel("Horizon", pan.panHorizon, 8, 5, panHorizon_XY, 1, UI_Mode.UI_Checkbox, 0, "Show HUD frame", 0, "Show ILS", 1, "Show Radar", 0 , "  with track"); // first!
 
                 //pi[a++] = new Panel("Center", pan.panCenter, 13, 8, panCenter_XY);
                 pi[a++] = new Panel("Pitch", pan.panPitch, 7, 1, panPitch_XY);
                 pi[a++] = new Panel("Roll", pan.panRoll, 13, 1, panRoll_XY);
                 pi[a++] = new Panel("Battery A", pan.panBatt_A, 14, 13, panBatt_A_XY, 1);
                 pi[a++] = new Panel("Battery B", pan.panBatt_B, 14, 12, panBatt_B_XY, 1);
-                pi[a++] = new Panel("Visible Sats", pan.panGPSats, 26, 11, panGPSats_XY, 1,0,"Icon in tail");
+                pi[a++] = new Panel("Visible Sats", pan.panGPSats, 26, 11, panGPSats_XY, 1, UI_Mode.UI_Checkbox, 0,"Icon in tail");
                 pi[a++] = new Panel("Real heading", pan.panCOG, 22, 14, panCOG_XY, 1);
-                pi[a++] = new Panel("GPS Coord", pan.panGPS, 1, 14, panGPS_XY, 1, 0, "use less precision (5 digits)", 0, "Show only fractional", 0, "Display in row");
-        //        pi[a++] = new Panel("GPS Coord 2", pan.panGPS2, 2, 0, panGPS2_XY, 1, 0, "use less precision (5 digits)", 0, "Show only fractional");
+                pi[a++] = new Panel("GPS Coord", pan.panGPS, 1, 14, panGPS_XY, 1, UI_Mode.UI_Checkbox, 0, "use less precision (5 digits)", 0, "Show only fractional", 0, "Display in row");
+                //        pi[a++] = new Panel("GPS Coord 2", pan.panGPS2, 2, 0, panGPS2_XY, 1, UI_Mode.UI_Checkbox, 0, "use less precision (5 digits)", 0, "Show only fractional");
 
-                pi[a++] = new Panel("Heading Rose", pan.panRose, 10, 11, panRose_XY, 0,0,"Marker below rose", 0, "Even panel length");
+                pi[a++] = new Panel("Heading Rose", pan.panRose, 10, 11, panRose_XY, 0, UI_Mode.UI_Checkbox, 0,"Marker below rose", 0, "Even panel length");
                 pi[a++] = new Panel("Heading", pan.panHeading, 21, 11, panHeading_XY, 0);
                 //          pi[a++] = new Panel("Heart Beat", pan.panMavBeat, 14, 15, panMavBeat_XY;
                 pi[a++] = new Panel("Home Direction", pan.panHomeDir, 14, 3, panHomeDir_XY);
@@ -301,20 +301,20 @@ namespace OSD {
                 pi[a++] = new Panel("WP Direction", pan.panWPDir, 4, 9, panWPDir_XY);
                 pi[a++] = new Panel("WP Distance", pan.panWPDis, 1, 11, panWPDis_XY, 1);
 
-                pi[a++] = new Panel("Altitude", pan.panAlt, 22, 3, panAlt_XY, 1, 0, "Reset to 0 on arming");
+                pi[a++] = new Panel("Altitude", pan.panAlt, 22, 3, panAlt_XY, 1, UI_Mode.UI_Checkbox, 0, "Reset to 0 on arming");
                 pi[a++] = new Panel("Home Altitude", pan.panHomeAlt, 22, 2, panHomeAlt_XY, 1);
-                pi[a++] = new Panel("Vertical Speed", pan.panClimb, 1, 8, panClimb_XY, 1, 0 , "show in m/s");
-                pi[a++] = new Panel("Battery Percent", pan.panBatteryPercent, 14, 15, panBatteryPercent_XY, 1, 0, "Show percent, not used mAH");
+                pi[a++] = new Panel("Vertical Speed", pan.panClimb, 1, 8, panClimb_XY, 1, UI_Mode.UI_Checkbox, 0 , "show in m/s");
+                pi[a++] = new Panel("Battery Percent", pan.panBatteryPercent, 14, 15, panBatteryPercent_XY, 1, UI_Mode.UI_Checkbox, 0, "Show percent, not used mAH");
                 pi[a++] = new Panel("Current", pan.panCur_A, 14, 14, panCurrA_XY, 1);
 
-                pi[a++] = new Panel("Velocity", pan.panVel, 1, 2, panVel_XY, 1, 0, "Show in m/s");
-                pi[a++] = new Panel("Air Speed", pan.panAirSpeed, 1, 1, panAirSpeed_XY, 1, 0, "Show in m/s");
+                pi[a++] = new Panel("Velocity", pan.panVel, 1, 2, panVel_XY, 1, UI_Mode.UI_Checkbox, 0, "Show in m/s");
+                pi[a++] = new Panel("Air Speed", pan.panAirSpeed, 1, 1, panAirSpeed_XY, 1, UI_Mode.UI_Checkbox, 0, "Show in m/s");
                 pi[a++] = new Panel("Throttle", pan.panThr, 1, 3, panThr_XY, 1);
                 pi[a++] = new Panel("Flight Mode", pan.panFlightMode, 1, 13, panFMod_XY, 1);
 
-                pi[a++] = new Panel("Wind Speed", pan.panWindSpeed, 24, 7, panWindSpeed_XY, 1, 0, "Show in m/s");
+                pi[a++] = new Panel("Wind Speed", pan.panWindSpeed, 24, 7, panWindSpeed_XY, 1, UI_Mode.UI_Checkbox, 0, "Show in m/s");
                 pi[a++] = new Panel("Warnings", pan.panWarn, 9, 4, panWarn_XY);
-                pi[a++] = new Panel("Time", pan.panTime, 23, 4, panTime_XY,-1,0,"Blinking semicolon");
+                pi[a++] = new Panel("Time", pan.panTime, 23, 4, panTime_XY,-1, UI_Mode.UI_Checkbox, 0,"Blinking semicolon");
                 pi[a++] = new Panel("RSSI", pan.panRSSI, 7, 13, panRSSI_XY, 1);
                 pi[a++] = new Panel("Tune", pan.panTune, 21, 10, panTune_XY, 1);
                 pi[a++] = new Panel("Efficiency", pan.panEff, 1, 11, panEff_XY, 1);
@@ -324,17 +324,17 @@ namespace OSD {
                 pi[a++] = new Panel("Trip Distance", pan.panDistance, 22, 2, panDistance_XY, 1);
                 pi[a++] = new Panel("Radar Scale", pan.panRadarScale, 23, 9, panRadarScale_XY, 1);
                 pi[a++] = new Panel("Flight Data", pan.panFData, 1, 2, panFdata_XY);
-                pi[a++] = new Panel("Message", pan.panMessage, 2, 10, panMessage_XY, 1, 0, "Not scroll if not fit" /*,0,"Not show screen number"*/ );
-                pi[a++] = new Panel("Sensor 1", pan.panSenor1, 0, 4, panSenor1_XY, -1, 1, "PWM input");
-                pi[a++] = new Panel("Sensor 2", pan.panSenor2, 0, 5, panSenor2_XY, -1, 1, "PWM input");
-                pi[a++] = new Panel("Sensor 3", pan.panSenor3, 0, 6, panSenor3_XY, -1, 1, "PWM input");
-                pi[a++] = new Panel("Sensor 4", pan.panSenor4, 0, 7, panSenor4_XY, -1, 1, "PWM input");
+                pi[a++] = new Panel("Message", pan.panMessage, 2, 10, panMessage_XY, 1, UI_Mode.UI_Checkbox, 0, "Not scroll if not fit" /*,0,"Not show screen number"*/ );
+                pi[a++] = new Panel("Sensor 1", pan.panSenor1, 0, 4, panSenor1_XY, -1, UI_Mode.UI_Checkbox, 1, "PWM input");
+                pi[a++] = new Panel("Sensor 2", pan.panSenor2, 0, 5, panSenor2_XY, -1, UI_Mode.UI_Checkbox, 1, "PWM input");
+                pi[a++] = new Panel("Sensor 3", pan.panSenor3, 0, 6, panSenor3_XY, -1, UI_Mode.UI_Checkbox, 1, "PWM input");
+                pi[a++] = new Panel("Sensor 4", pan.panSenor4, 0, 7, panSenor4_XY, -1, UI_Mode.UI_Checkbox, 1, "PWM input");
                  //pi[a++] = new Panel("Baro Alt", pan.panBaroAlt, 1, 4, panBroAlt_XY, 1, -1);
                 pi[a++] = new Panel("GPS HDOP", pan.panHdop, 1, 6, panHdop_XY, 1);
-                pi[a++] = new Panel("Channel state", pan.panState, 1, 5, panState_XY, 1, -2, "Select channel");
-                pi[a++] = new Panel("Channel Scale", pan.panScale,  1, 5, panScale_XY, 1, -2, "Select channel");
-                pi[a++] = new Panel("Channel ExtScale", pan.panEScale, 1, 5, panEScale_XY, 1, -2, "Select channel");
-                pi[a++] = new Panel("Channel Value", pan.panCvlaue, 1, 5, panCvalue_XY, 1, -2, "Select channel");
+                pi[a++] = new Panel("Channel state", pan.panState, 1, 5, panState_XY, 1, UI_Mode.UI_Combo, -2, "Select channel");
+                pi[a++] = new Panel("Channel Scale", pan.panScale,  1, 5, panScale_XY, 1, UI_Mode.UI_Combo, -2, "Select channel");
+                pi[a++] = new Panel("Channel ExtScale", pan.panEScale, 1, 5, panEScale_XY, 1, UI_Mode.UI_Combo, -2, "Select channel");
+                pi[a++] = new Panel("Channel Value", pan.panCvlaue, 1, 5, panCvalue_XY, 1, UI_Mode.UI_Combo, -2, "Select channel");
 
 
                 osd_functions_N = a;
@@ -1234,7 +1234,8 @@ namespace OSD {
                             if (pi.sign >= 0)
                                 pi.sign = (p.x & 0x80) == 0 ? 1 : 0; // inverted
 
-                            if (pi.Altf == -2) {
+                            if (pi.ui_mode == UI_Mode.UI_Combo) {
+                                // pi.Altf = (p.y & 0x40) == 0 ? 0 : 1; // TODO -TY - is this right?
                                 pi.Alt2 = (p.y & 0x20) == 0 ? 0 : 1;                            
                                 pi.Alt3 = (p.y & 0x10) == 0 ? 0 : 1;                            
                                 pi.Alt4 = (p.x & 0x40) == 0 ? 0 : 1;
@@ -1805,29 +1806,14 @@ namespace OSD {
                                             //scr[k].panelItems[a] = new Panel(pi.name, pi.show, int.Parse(strings[1]), int.Parse(strings[2]), pi.pos);
                                             pi.x = int.Parse(strings[1]);
                                             pi.y = int.Parse(strings[2]);
-                                            pi.sign=1;
-                                            try {
-                                                pi.sign = int.Parse(strings[4]);
-                                            } catch { }
-                                            pi.Altf=0;
-                                            try {
-                                                pi.Altf = int.Parse(strings[5]);
-                                            } catch { }
-
-                                            pi.Alt2 = 0;
-                                            try {
-                                                pi.Alt2 = int.Parse(strings[6]);
-                                            } catch { }
-
-                                            pi.Alt3 = 0;
-                                            try {
-                                                pi.Alt3 = int.Parse(strings[7]);
-                                            } catch { }
-
-                                            pi.Alt4 = 0;
-                                            try {
-                                                pi.Alt4 = int.Parse(strings[8]);
-                                            } catch { }
+                                            if (!int.TryParse(strings[4], out pi.sign)) {
+                                                pi.sign = 1;
+                                            }
+                                            // if TryParse fails, default is zero
+                                            int.TryParse(strings[5], out pi.Altf);
+                                            int.TryParse(strings[6], out pi.Alt2);
+                                            int.TryParse(strings[7], out pi.Alt3);
+                                            int.TryParse(strings[8], out pi.Alt4);
 
                                             TreeNode[] tnArray = scr[k].LIST_items.Nodes.Find(scr[k].panelItems[a].name, true);
                                             if (tnArray.Length > 0)

--- a/Tools/OSD/Panel.cs
+++ b/Tools/OSD/Panel.cs
@@ -2,10 +2,15 @@ using System;
 using System.Windows.Forms;
 
 namespace OSD {
-	
-	// проще и лучше чем эти туплы :)
-	
-	[Serializable]// "Pitch", pan.panPitch, 22, 10, panPitch_en_ADDR, panPitch_x_ADDR, panPitch_y_ADDR
+
+    public enum UI_Mode {
+        UI_Checkbox = 0,
+        UI_Combo = 1
+    };
+
+    // проще и лучше чем эти туплы :)
+
+    [Serializable]// "Pitch", pan.panPitch, 22, 10, panPitch_en_ADDR, panPitch_x_ADDR, panPitch_y_ADDR
 	public class Panel { 
 		public string name;
 		public int x, y;
@@ -20,12 +25,12 @@ namespace OSD {
         public string alt3_text;
         public int Alt4;
         public string alt4_text;
+        public UI_Mode ui_mode;
 
 
+        //public TreeNode node;
 
-		//public TreeNode node;
-
-        public Panel(String aname, Func<int, int, int, int, int> ashow, int ax, int ay, int apos, int asign = -1, int fAlt = -1, string text = "", int fAlt2 = -1, string text2 = "", int fAlt3 = -1, string text3 = "", int fAlt4 = -1, string text4 = "") {
+        public Panel(String aname, Func<int, int, int, int, int> ashow, int ax, int ay, int apos, int asign = -1, UI_Mode uim = UI_Mode.UI_Checkbox, int fAlt = -1, string text = "", int fAlt2 = -1, string text2 = "", int fAlt3 = -1, string text3 = "", int fAlt4 = -1, string text4 = "") {
 			name = aname;
 			show = ashow;
 			x = ax;
@@ -40,6 +45,7 @@ namespace OSD {
             alt3_text = text3;
             Alt4 = fAlt4;
             alt4_text = text4;
+            ui_mode = uim;
         }
 
         public void copyFrom(Panel other) {
@@ -57,6 +63,7 @@ namespace OSD {
             alt3_text = other.alt3_text;
             Alt4 = other.Alt4;
             alt4_text = other.alt4_text;
+            ui_mode = other.ui_mode;
         }
 	}
 }

--- a/Tools/OSD/osd_screen.cs
+++ b/Tools/OSD/osd_screen.cs
@@ -438,7 +438,7 @@ namespace OSD
             chkSign.Checked = thing.sign == 1;
             chkSign.Visible = thing.sign != -1;
 
-            if (thing.Altf == -2) {
+            if (thing.ui_mode == UI_Mode.UI_Combo) {
                 int n = osd.getAlt(thing)/2;
                 cbNumber.SelectedIndex =n;
                 cbNumber.Visible = true;


### PR DESCRIPTION
There were a few things I was unsure about.  Perhaps you can double check:

       public int getAlt(Panel p){
            return (p.Altf==1?1:0) + (p.Alt2==1?2:0) + (p.Alt3==1?4:0) + (p.Alt4==1?8:0);
        }

            if (thing.ui_mode == UI_Mode.UI_Combo) {
                int n = osd.getAlt(thing)/2;
                cbNumber.SelectedIndex =n;

            if (pi.ui_mode == UI_Mode.UI_Combo) {
               // pi.Altf = (p.y & 0x40) == 0 ? 0 : 1; // TODO -TY - is this right?

Should these continue to use -2 to set the altf?
                pi[a++] = new Panel("Channel state", pan.panState, 1, 5, panState_XY, 1, UI_Mode.UI_Combo, -2, "Select channel");
