### PR TITLE
Fixes to MWII: roll/pitch, voltage and home dir

### DIFF
--- a/MinimOsd_Extra/Func.h
+++ b/MinimOsd_Extra/Func.h
@@ -691,7 +691,7 @@ again:
 
 	memset( &msgbuf.bytes[0], 0, sizeof(msgbuf.bytes)); // clear packet buffer to initial state
     
-#if defined(AUTOBAUD)
+#if defined(AUTOBAUD) && !defined(USE_MWII)
 	Serial.end();
 	static uint8_t last_pulse = 15; // 57600 by default
 	uint8_t pulse=255;

--- a/MinimOsd_Extra/Func.h
+++ b/MinimOsd_Extra/Func.h
@@ -691,7 +691,7 @@ again:
 
 	memset( &msgbuf.bytes[0], 0, sizeof(msgbuf.bytes)); // clear packet buffer to initial state
     
-#if defined(AUTOBAUD) && !defined(USE_MWII)
+#if defined(AUTOBAUD)
 	Serial.end();
 	static uint8_t last_pulse = 15; // 57600 by default
 	uint8_t pulse=255;

--- a/MinimOsd_Extra/protocols/cleanflight_core.h
+++ b/MinimOsd_Extra/protocols/cleanflight_core.h
@@ -618,9 +618,9 @@ typedef struct {
 } MW_ATTITUDE_t;
 */
 //	r_struct((uint8_t*)&MW_ATT,6);
+	osd_att.roll = (int16_t)mwii_read_uint(offsetof(MW_ATTITUDE_t, Angle[0]) ) / 10;  // in centidegrees, thanks pwbecker
+	osd_att.pitch  = (int16_t)mwii_read_uint(offsetof(MW_ATTITUDE_t, Angle[1]) ) / 10;
 	osd_heading = mwii_read_uint(offsetof(MW_ATTITUDE_t, Heading) );
-	osd_att.roll = mwii_read_uint(offsetof(MW_ATTITUDE_t, Angle[0]) ) / 10;  // in centidegrees, thanks pwbecker
-	osd_att.pitch  = mwii_read_uint(offsetof(MW_ATTITUDE_t, Angle[1]) ) / 10;
 //	mwii_read_len(&osd_att,offsetof(MW_ATTITUDE_t, Angle), sizeof(osd_att)); // opposite direction
 DBG_PRINTF("got attitude roll=%d pitch=%d head=%d\n",osd_heading, osd_att.roll, osd_att.pitch);
 	break;
@@ -650,7 +650,7 @@ typedef struct {
 */
 //	r_struct((uint8_t*)&MW_ANALOG,7);
 	if(!FLAGS.useExtVbattA){
-	    osd_vbat_A              = mwii_read_uint(offsetof(MW_ANALOG_t, VBat) );
+	    osd_vbat_A              = 100u * (uint16_t)mwii_read_uint(offsetof(MW_ANALOG_t, VBat) );
 	    osd_battery_remaining_A = mwii_read_uint(offsetof(MW_ANALOG_t, pMeterSum) );
 	}
 	if (!FLAGS.useExtCurr)

--- a/MinimOsd_Extra/protocols/cleanflight_core.h
+++ b/MinimOsd_Extra/protocols/cleanflight_core.h
@@ -607,7 +607,7 @@ typedef struct {
     case MSP_COMP_GPS:
 	//r_struct((uint8_t*)&GPS.distanceToHome,4);
 	osd_home_distance  = mwii_read_uint(0 );
-	osd_home_direction = grad_to_sect(mwii_read_uint(2) );
+	osd_home_direction = mwii_read_uint(2);
 	break;
 
     case MSP_ATTITUDE:


### PR DESCRIPTION
roll/pitch - missing case
voltage - missing scale
home dir - double call to grad to sect (another one is in panel) - this may not completely fix home arrow